### PR TITLE
docs: add comprehensive Cursor rules

### DIFF
--- a/.cursor/rules/01-style-and-conventions.md
+++ b/.cursor/rules/01-style-and-conventions.md
@@ -3,6 +3,7 @@
 - **Functional > OO** (except Flask views where reasonable).
 - **Type hints** everywhere; return `TypedDict`/`dataclass` if needed, but prefer plain dicts with typed signatures (RORO).
 - **Names**: `lower_snake_case` for files, modules, funcs. Use auxiliary-verb flags: `is_active`, `has_permission`, `should_cache`.
+- **Exports**: expose routes and utilities with explicit names; avoid wildcard imports.
 - **Structure**: keep logic small and composable; avoid duplication; push shared logic to `app/utils.py`.
 - **Control flow**: guard-clauses first; early return on invalid states; keep “happy path” last; avoid unnecessary `else`.
 - **I/O boundaries**: routes = thin; services/validators/utilities = thick.

--- a/.cursor/rules/02-python-flask-core.md
+++ b/.cursor/rules/02-python-flask-core.md
@@ -1,0 +1,8 @@
+# Python & Flask Core
+
+- Use `def` with type hints for all functions.
+- Prefer functional, declarative code; limit classes to Flask views or lightweight data containers.
+- Build the app with the factory pattern (`create_app`) and register blueprints inside it.
+- Load configuration from `Config` and environment variables; avoid hard-coded settings.
+- Pass dependencies explicitly or via `current_app`; avoid global state.
+- Use descriptive variable names and the RORO (Receive an Object, Return an Object) pattern.

--- a/.cursor/rules/03-routing-and-blueprints.md
+++ b/.cursor/rules/03-routing-and-blueprints.md
@@ -1,0 +1,7 @@
+# Routing & Blueprints
+
+- Organize endpoints by blueprint under `app/blueprints/`.
+- Use Flask-RESTful or class-based views for REST APIs.
+- Export routes and resources with explicit names for easy imports.
+- Keep route handlers thin; delegate work to services, validators, or utilities.
+- Apply consistent blueprint names and URL prefixes (e.g., `api`, `public`, `admin`).

--- a/.cursor/rules/04-validation-and-serialization.md
+++ b/.cursor/rules/04-validation-and-serialization.md
@@ -1,0 +1,7 @@
+# Validation & Serialization
+
+- Validate input at the start of functions using guard clauses and early returns.
+- Use Marshmallow schemas or dedicated validator functions for request data.
+- Sanitize and normalize user input (strip, lowercase, remove unsafe characters).
+- Return structured errors with helpful messages; log validation failures.
+- Serialize responses via schemas or explicit dicts following the RORO pattern.

--- a/.cursor/rules/05-database-and-migrations.md
+++ b/.cursor/rules/05-database-and-migrations.md
@@ -1,0 +1,7 @@
+# Database & Migrations
+
+- Use Flask-SQLAlchemy for ORM models in `app/models.py`.
+- Manage schema changes with Flask-Migrate; run migrations on startup in production.
+- Reuse connections through pooling (`app/database.py`) and close sessions promptly.
+- Keep queries parameterized; prefer ORM relationships over raw SQL where possible.
+- Index frequently queried columns and document migration steps.

--- a/.cursor/rules/06-security-and-auth.md
+++ b/.cursor/rules/06-security-and-auth.md
@@ -1,0 +1,7 @@
+# Security & Auth
+
+- Enforce HTTPS and a strict Content Security Policy via Talisman in production.
+- Store secrets in environment variables and validate them at startup.
+- Use Flask-JWT-Extended or session-based auth with hashed passwords.
+- Apply CSRF protection for state-changing requests.
+- Rate-limit login attempts and log all security-relevant events.

--- a/.cursor/rules/07-performance-and-caching.md
+++ b/.cursor/rules/07-performance-and-caching.md
@@ -1,0 +1,7 @@
+# Performance & Caching
+
+- Cache expensive computations with Flask-Caching and set sensible expirations.
+- Optimize database queries; use indexing and avoid N+1 patterns.
+- Reuse pooled connections and close them quickly.
+- Offload heavy work to background tasks (e.g., Celery or scripts).
+- Avoid redundant computation and prefer iteration over duplication.

--- a/.cursor/rules/08-monitoring-and-ops.md
+++ b/.cursor/rules/08-monitoring-and-ops.md
@@ -1,0 +1,7 @@
+# Monitoring & Ops
+
+- Use `current_app.logger` for structured logs with context.
+- Expose health, memory, and metrics endpoints for remote monitoring.
+- Utilize scripts in `scripts/` (e.g., `memory_monitor.py`) for performance tracking.
+- Watch key metrics: response time, memory, CPU, and database connections.
+- Ensure teardown hooks clean up resources and connections.

--- a/.cursor/rules/09-testing.md
+++ b/.cursor/rules/09-testing.md
@@ -1,0 +1,7 @@
+# Testing
+
+- Use `pytest` with the Flask test client for unit and integration tests.
+- Create fixtures for the app, database, and common payloads.
+- Run `python -m pytest tests/ -v` before committing.
+- Avoid network calls or external state in tests; keep them deterministic.
+- Aim for thorough coverage of validators, routes, and edge cases.

--- a/.cursor/rules/10-api-docs.md
+++ b/.cursor/rules/10-api-docs.md
@@ -1,0 +1,5 @@
+# API Documentation
+
+- Use Flask-RESTX or Flasgger to generate Swagger/OpenAPI documentation.
+- Document every endpoint with request and response schemas, including auth requirements.
+- Keep docs versioned with the codebase and validate schemas in tests when possible.

--- a/.cursor/rules/11-frontend-and-pwa.md
+++ b/.cursor/rules/11-frontend-and-pwa.md
@@ -1,0 +1,6 @@
+# Frontend & PWA
+
+- Place templates in `templates/` and static assets in `static/` with `lower_snake_case` names.
+- Maintain PWA assets (`sw.js`, manifest) and ensure service workers run over HTTPS.
+- Keep the UI mobile-first and accessible; test the `/pwa-test` route for debugging.
+- Serve only sanitized data to templates to avoid XSS.

--- a/.cursor/rules/12-deployment.md
+++ b/.cursor/rules/12-deployment.md
@@ -1,0 +1,6 @@
+# Deployment
+
+- Use Gunicorn or uWSGI as the production WSGI server.
+- Configure environments via `Config` and environment variables; fail fast if required vars are missing.
+- Enable automatic migrations on startup and verify database connectivity.
+- Collect structured logs and metrics in production (e.g., Render.com dashboards).

--- a/.cursor/rules/13-refactors-and-safety-rails.md
+++ b/.cursor/rules/13-refactors-and-safety-rails.md
@@ -1,0 +1,6 @@
+# Refactors & Safety Rails
+
+- Preserve existing behavior; add regression tests before major refactors.
+- Keep commits small, logical, and easily revertible.
+- Use feature flags or configuration checks for risky changes.
+- Run full tests and linting before merging.

--- a/.cursor/rules/99-cursor-task-recipes.md
+++ b/.cursor/rules/99-cursor-task-recipes.md
@@ -1,0 +1,17 @@
+# Cursor Task Recipes
+
+## Add a new API endpoint
+1. Create the route in the appropriate blueprint.
+2. Implement validation and business logic in `app/` modules.
+3. Add tests under `tests/` and update API documentation.
+4. Run `python -m pytest tests/ -v` before committing.
+
+## Update database schema
+1. Modify models in `app/models.py` and create a migration.
+2. Update validators and serializers as needed.
+3. Apply migrations and run tests.
+
+## Fix a bug
+1. Reproduce the issue with a failing test.
+2. Apply the smallest fix and add logging where helpful.
+3. Ensure tests pass and update docs if behavior changes.


### PR DESCRIPTION
## Summary
- document Python & Flask core principles and project guidelines in `.cursor/rules`
- expand rules for routing, validation, database, security, performance, monitoring, testing, API docs, frontend, deployment, refactors, and task recipes
- clarify style guide with explicit exports

## Testing
- `python3 -m pytest tests/ -v` *(fails: connection refused to Postgres and assertion mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68a772c46b80832abf4fafcc2456f4cb